### PR TITLE
Move database resource into ENV entry `target_db`

### DIFF
--- a/src/_index.yaml
+++ b/src/_index.yaml
@@ -3,7 +3,7 @@ namespace: wippy.embeddings
 
 entries:
   # Requirements
-  - name: target_db
+  - name: requirement-target_db
     kind: ns.requirement
     meta:
       description: "Application database ID"

--- a/src/_index.yaml
+++ b/src/_index.yaml
@@ -2,6 +2,17 @@ version: "1.0"
 namespace: wippy.embeddings
 
 entries:
+  # Requirements
+  - name: target_db
+    kind: ns.requirement
+    meta:
+      description: "Application database ID"
+    targets:
+      - entry: wippy.embeddings.migrations:01_create_embeddings_table
+        path: ".meta.target_db"
+      - entry: target_db
+        path: ".default"
+
   # Dependencies
   - name: __dependency.wippy.llm
     kind: "ns.dependency"
@@ -24,6 +35,20 @@ entries:
     component: "wippy/test"
     version: ">=v0.0.7"
 
+  # wippy.embeddings:envs
+  - name: envs
+    kind: env.storage.os
+    meta:
+      type: envstorage
+      comment: OS storage for environment variables
+
+  # wippy.embeddings:target_db
+  - name: target_db
+    kind: env.variable
+    meta:
+      type: config_key
+      comment: Database resource identifier
+    storage: wippy.embeddings:envs
 
   # wippy.embeddings:embedding_repo
   - name: embedding_repo

--- a/src/embedding_repo.lua
+++ b/src/embedding_repo.lua
@@ -1,9 +1,10 @@
 local sql = require("sql")
 local json = require("json")
 local uuid = require("uuid")
+local env = require("env")
 
 -- Constants
-local DB_RESOURCE = "app:db"
+local DB_RESOURCE, _ = env.get("wippy.embeddings:target_db")
 local DEFAULT_SEARCH_LIMIT = 10
 
 local embedding_repo = {}

--- a/src/embedding_repo_test.lua
+++ b/src/embedding_repo_test.lua
@@ -1,6 +1,7 @@
 local test = require("test")
 local sql = require("sql")
 local uuid = require("uuid")
+local env = require("env")
 local embedding_repo = require("embedding_repo")
 
 local function define_tests()
@@ -29,7 +30,8 @@ local function define_tests()
 
         -- Clean up after all tests
         after_all(function()
-            local db, err = sql.get("app:db")
+            local db_resource, _ = env.get("wippy.embeddings:target_db")
+            local db, err = sql.get(db_resource)
             if err then
                 print("Warning: Could not connect to database for cleanup: " .. err)
                 return

--- a/src/migrations/_index.yaml
+++ b/src/migrations/_index.yaml
@@ -2,15 +2,6 @@ version: "1.0"
 namespace: wippy.embeddings.migrations
 
 entries:
-  # Requirements
-  - name: app_db
-    kind: ns.requirement
-    meta:
-      description: "Application database ID"
-    targets:
-      - entry: 01_create_embeddings_table
-        path: ".meta.target_db"
-
   # wippy.embeddings.migrations:01_create_embeddings_table
   - name: 01_create_embeddings_table
     kind: function.lua


### PR DESCRIPTION
## What was changed

Declared requirement `target_db` with related ENV

## Documentation <!--- Remove if not needed -->

```
  - name: __dependency.wippy.embeddings
    kind: "ns.dependency"
    meta:
      description: "Embeddings component"
    component: "wippy/embeddings"
    version: ">=v0.0.1"
    parameters:
      - name: "target_db"
        value: "app:db"
```