### PR TITLE
 Move ENVs into `env` namespace; fix naming

### DIFF
--- a/src/_index.yaml
+++ b/src/_index.yaml
@@ -10,7 +10,7 @@ entries:
     targets:
       - entry: wippy.embeddings.migrations:01_create_embeddings_table
         path: ".meta.target_db"
-      - entry: env-target_db
+      - entry: wippy.embeddings.env:target_db
         path: ".default"
     default: "app:db"
 
@@ -35,21 +35,6 @@ entries:
       description: "Testing component"
     component: "wippy/test"
     version: ">=v0.2.0"
-
-  # wippy.embeddings:envs
-  - name: envs
-    kind: env.storage.os
-    meta:
-      type: envstorage
-      comment: OS storage for environment variables
-
-  # wippy.embeddings:env-target_db
-  - name: env-target_db
-    kind: env.variable
-    meta:
-      type: config_key
-      comment: Database resource identifier
-    storage: wippy.embeddings:envs
 
   # wippy.embeddings:embedding_repo
   - name: embedding_repo

--- a/src/embedding_repo.lua
+++ b/src/embedding_repo.lua
@@ -10,7 +10,7 @@ local embedding_repo = {}
 
 -- Helper function to get database connection
 local function get_db()
-    local DB_RESOURCE, _ = env.get("wippy.embeddings:env-target_db")
+    local DB_RESOURCE, _ = env.get("wippy.embeddings.env:target_db")
 
     local db, err = sql.get(DB_RESOURCE)
     if err then

--- a/src/embedding_repo_test.lua
+++ b/src/embedding_repo_test.lua
@@ -30,7 +30,7 @@ local function define_tests()
 
         -- Clean up after all tests
         after_all(function()
-            local db_resource, _ = env.get("wippy.embeddings:env-target_db")
+            local db_resource, _ = env.get("wippy.embeddings.env:target_db")
             local db, err = sql.get(db_resource)
             if err then
                 print("Warning: Could not connect to database for cleanup: " .. err)

--- a/src/env/_index.yaml
+++ b/src/env/_index.yaml
@@ -1,0 +1,19 @@
+version: "1.0"
+namespace: wippy.embeddings.env
+
+entries:
+  # wippy.embeddings.env:envs
+  - name: envs
+    kind: env.storage.os
+    meta:
+      type: envstorage
+      comment: OS storage for environment variables
+
+  # wippy.embeddings.env:target_db
+  - name: target_db
+    kind: env.variable
+    meta:
+      type: config_key
+      comment: Database resource identifier
+      private: true
+    storage: wippy.embeddings.migrations:envs


### PR DESCRIPTION
Move ENVs into `env` namespace;
Rename `env-target_db` into `target_db`